### PR TITLE
FEAT: Adiciona API de jogos com rawg.io #15

### DIFF
--- a/src/plugins/axios.js
+++ b/src/plugins/axios.js
@@ -1,12 +1,20 @@
 import axios from "axios";
 
 const token = import.meta.env.VITE_API_TOKEN;
+const key = import.meta.env.VITE_API_KEY;
 
-const api = axios.create({
+const apiTMDB = axios.create({
     baseURL: 'https://api.themoviedb.org/3/',
     headers: {
         Authorization: `Bearer ${token}`
     }
 });
 
-export default api;
+const apiRAWG = axios.create({
+    baseURL: 'https://api.rawg.io/api/',
+    headers: {
+        Authorization: `Bearer ${key}`
+    }
+})
+
+export { apiTMDB, apiRAWG };


### PR DESCRIPTION
### Notas sobre a atualização

1. Adiciona a API rawg.io para buscar jogos;
- Agora, ao invés de exportar o plugin como default, utiliza-se as chaves para exportar as duas API's em plugins/axios.js; assim, se você for chamar qualquer uma das API's, você deverá chamá-la como { apiTMDB } ou { apiRAWG }, respeitando as chaves.